### PR TITLE
Create Wheelbarrow Terraform Modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # wheelbarrow-terraform-modules
-Terraform code defining the GCP infrastructure for project wheelbarrow - environment and region agnostic.
+
+Terraform code defining the GCP infrastructure for project wheelbarrow.
+
+This code is environment (dev,stage,prod) and region (europe-west1, europe-west2) agnostic. It is intended to be called from a higher level repo that provides appropriate environment and region specific values.
+
+We're using [terragrunt](https://github.com/gruntwork-io/terragrunt) for our Terraform workflow.
+
+## Usage
+
+Example usage of the `service_accounts` module.
+
+Create a `terragrunt.hcl` file.
+```
+# Use Terragrunt to download the module code
+terraform {
+   source = "git::git@github.com:fuzzylabs/wheelbarrow-terraform-modules.git//service_accounts?ref=master"
+}
+
+# Provide variables for the module
+inputs = {
+  location = "europe-west1"
+  project  = "wheelbarrow-dev"
+}
+```
+
+Then run Terragrunt.
+```
+terragrunt apply
+```
+
+Robert is your father's brother.
+
+## TODO
+
+* Add an inventory of what modules we have.
+* Create a README.md for each module - documenting usage, inputs, outputs.
+* Tests.
+* Make a reference in this README to remote state and the general Terragrunt pattern of usage.

--- a/big_query/main.tf
+++ b/big_query/main.tf
@@ -1,0 +1,13 @@
+provider "google" {
+  project = var.project
+  region  = var.location
+}
+
+terraform {
+  backend "gcs" {}
+}
+
+resource "google_bigquery_dataset" "default" {
+  location   = var.location
+  dataset_id = var.dataset_id
+}

--- a/big_query/variables.tf
+++ b/big_query/variables.tf
@@ -1,0 +1,14 @@
+variable "location" {
+  description = "The GCP Location in which resources are created"
+  type        = string
+}
+
+variable "project" {
+  description = "The GCP Project in which resources are created"
+  type        = string
+}
+
+variable "dataset_id" {
+  description = "The name of the Big Query dataset"
+  type        = string
+}

--- a/cloud_functions/main.tf
+++ b/cloud_functions/main.tf
@@ -1,0 +1,41 @@
+provider "google" {
+  project = var.project
+  region  = var.location
+}
+
+terraform {
+  backend "gcs" {}
+}
+
+data "archive_file" "default" {
+  count       = "${length(var.cloud_functions)}"
+  type        = "zip"
+  source_dir  = "${var.source_dir}/${lookup(var.cloud_functions[count.index], "name")}"
+  output_path = "${path.module}/tmp/${lookup(var.cloud_functions[count.index], "name")}.zip"
+
+}
+
+resource "google_storage_bucket_object" "default" {
+  count      = "${length(var.cloud_functions)}"
+  name       = "${lookup(var.cloud_functions[count.index], "name")}.zip"
+  bucket     = "${var.billing_org_id}_${var.customer}_${var.project_group}_${var.env}_cloud-functions"
+  source     = "${path.module}/tmp/${lookup(var.cloud_functions[count.index], "name")}.zip"
+  depends_on = ["data.archive_file.default"]
+}
+
+resource "google_cloudfunctions_function" "default" {
+  count       = "${length(var.cloud_functions)}"
+  project     = var.project
+  region      = var.location
+  name        = "${lookup(var.cloud_functions[count.index], "name")}"
+  description = "${lookup(var.cloud_functions[count.index], "description")}"
+  runtime     = "${lookup(var.cloud_functions[count.index], "runtime")}"
+
+  available_memory_mb   = "${lookup(var.cloud_functions[count.index], "memory")}"
+  source_archive_bucket = "${var.billing_org_id}_${var.customer}_${var.project_group}_${var.env}_cloud-functions"
+  source_archive_object = "${lookup(var.cloud_functions[count.index], "name")}.zip"
+  trigger_http          = true
+  timeout               = 60
+  entry_point           = "${lookup(var.cloud_functions[count.index], "entry_point")}"
+  service_account_email = "${lookup(var.cloud_functions[count.index], "service_account_email")}"
+}

--- a/cloud_functions/variables.tf
+++ b/cloud_functions/variables.tf
@@ -45,7 +45,6 @@ variable "cloud_functions" {
       "description" : "Training Function",
       "runtime" : "go111",
       "memory" : "128",
-      "entry_point" : "Train",
       "service_account_email" : "cloud-function@wheelbarrow-dev.iam.gserviceaccount.com"
     }
   ]

--- a/cloud_functions/variables.tf
+++ b/cloud_functions/variables.tf
@@ -1,0 +1,52 @@
+# Note the structure of how we organise resources in GCP
+# billing_org_id (organisation) -> customer (folder) -> project_group (folder) -> project (project)
+
+variable "location" {
+  description = "The GCP Location in which resources are created"
+  type        = string
+}
+
+variable "billing_org_id" {
+  description = "The ID of the GCP billing organisation"
+  type        = string
+}
+
+variable "customer" {
+  description = "The name of the parent customer (GCP folder) in which the $project_group resides"
+  type        = string
+}
+
+variable "project_group" {
+  description = "The name of the project_group (GCP folder) in which the $project resides"
+  type        = string
+}
+
+variable "project" {
+  description = "The GCP Project in which resources are created, typically $project_group-$env"
+  type        = string
+}
+
+variable "env" {
+  description = "The name of the environment (dev|qa|prod)"
+  type        = string
+}
+
+variable "source_dir" {
+  description = "The path to the source code of the cloud functions"
+  type        = string
+}
+
+variable "cloud_functions" {
+  description = "A list of maps containing cloud function attributes"
+  type        = list
+  default = [
+    {
+      "name" : "train",
+      "description" : "Training Function",
+      "runtime" : "go111",
+      "memory" : "128",
+      "entry_point" : "Train",
+      "service_account_email" : "cloud-function@wheelbarrow-dev.iam.gserviceaccount.com"
+    }
+  ]
+}

--- a/cloud_storage/main.tf
+++ b/cloud_storage/main.tf
@@ -1,0 +1,21 @@
+provider "google" {
+  project = var.project
+  region  = var.location
+}
+
+terraform {
+  backend "gcs" {}
+}
+
+# Bucket names must be globally unique, hence the naming convention.
+resource "google_storage_bucket" "cloud_functions" {
+  location      = var.location
+  name          = "${var.billing_org_id}_${var.customer}_${var.project_group}_${var.env}_cloud-functions"
+  storage_class = var.storage_class
+}
+
+resource "google_storage_bucket" "ml_resources" {
+  location      = var.location
+  name          = "${var.billing_org_id}_${var.customer}_${var.project_group}_${var.env}_ml-resources"
+  storage_class = var.storage_class
+}

--- a/cloud_storage/outputs.tf
+++ b/cloud_storage/outputs.tf
@@ -1,0 +1,3 @@
+output "ml-resources-name" {
+  value = google_storage_bucket.ml_resources.name
+}

--- a/cloud_storage/variables.tf
+++ b/cloud_storage/variables.tf
@@ -1,0 +1,38 @@
+# Note the structure of how we organise resources in GCP
+# billing_org_id (organisation) -> customer (folder) -> project_group (folder) -> project (project)
+
+variable "location" {
+  description = "The GCP Location in which resources are created"
+  type        = string
+}
+
+variable "billing_org_id" {
+  description = "The ID of the GCP billing organisation"
+  type        = string
+}
+
+variable "customer" {
+  description = "The name of the parent customer (GCP folder) in which the $project_group resides"
+  type        = string
+}
+
+variable "project_group" {
+  description = "The name of the project_group (GCP folder) in which the $project resides"
+  type        = string
+}
+
+variable "project" {
+  description = "The GCP Project in which resources are created, typically $project_group-$env"
+  type        = string
+}
+
+variable "env" {
+  description = "The name of the environment (dev|qa|prod)"
+  type        = string
+}
+
+variable "storage_class" {
+  description = "The storage class of the Cloud Storage Bucket"
+  type        = string
+  default     = "REGIONAL"
+}

--- a/service_accounts/main.tf
+++ b/service_accounts/main.tf
@@ -1,0 +1,20 @@
+provider "google" {
+  project = var.project
+  region  = var.location
+}
+
+terraform {
+  backend "gcs" {}
+}
+
+module "cloud_function" {
+  source   = "github.com/fuzzylabs/terraform-google-service-account?ref=master"
+  location = var.location
+  project  = var.project
+  name     = "cloud-function"
+  roles = [
+    "roles/viewer",
+    "roles/storage.objectAdmin",
+    "roles/ml.developer"
+  ]
+}

--- a/service_accounts/variables.tf
+++ b/service_accounts/variables.tf
@@ -1,0 +1,9 @@
+variable "location" {
+  description = "The GCP Location in which resources are created"
+  type        = string
+}
+
+variable "project" {
+  description = "The GCP Project in which resources are created, typically $project_group-$env"
+  type        = string
+}


### PR DESCRIPTION
This code has been copied from wheelbarrow/terraform/modules.

This allow us to:

a) Not use a relative path as the `source` when referencing these modules.
b) Potentially version references to these repos using tags / branches etc.